### PR TITLE
Feat: `command_pattern` fixes: #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ return {
   },
   opts = {
     paths = { "~/dev/*" }, --custom path set by user
+    -- custom find command set by the user. Default should always work on unix unless user has heavily modified tools and/or PATH
+    -- for Windows Users: installing `fd` is recommended with the equivalent `fd` command
+    -- "fd . %s -td -H -E '.git' --min-depth %d --max-depth %d"
+    command_pattern = "find %s -mindepth %d -maxdepth %d -type d -not -name '.git'",
     newProjectPath = "~/dev/", --custom path for new projects
     file_explorer = function(dir) --custom file explorer set by user
       vim.cmd("Neotree close")
@@ -42,6 +46,10 @@ return {
   lazy = false,
 }
 ```
+
+## Optional dependencies
+
+`fd` - Install `fd` from [sharkdp](https://github.com/sharkdp/fd)
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ return {
     paths = { "~/dev/*" }, --custom path set by user
     -- custom find command set by the user. Default should always work on unix unless user has heavily modified tools and/or PATH
     -- for Windows Users: installing `fd` is recommended with the equivalent `fd` command
-    -- "fd . %s -td -H -E '.git' --min-depth %d --max-depth %d"
+    -- "fd . %s -td --min-depth %d --max-depth %d"
     command_pattern = "find %s -mindepth %d -maxdepth %d -type d -not -name '.git'",
     newProjectPath = "~/dev/", --custom path for new projects
     file_explorer = function(dir) --custom file explorer set by user

--- a/lua/project_explorer/config.lua
+++ b/lua/project_explorer/config.lua
@@ -2,6 +2,7 @@ local M = {}
 
 M.config = {
 	paths = { "~/dev", "~/projects" }, -- Default paths
+	command_pattern = "find %s -mindepth %d -maxdepth %d -type d -not -name '.git'",
 	newProjectPath = nil,
 	file_explorer = nil,
 	post_open_hook = function(dir)

--- a/lua/project_explorer/explorer.lua
+++ b/lua/project_explorer/explorer.lua
@@ -143,7 +143,9 @@ local function create_finder(favorites_only)
 			return favorites[entry]
 		end, results) or results,
 		entry_maker = function(entry)
-			local name = vim.fn.fnamemodify(entry, ":t")
+			-- Removes the trailing slash that is always included within windows
+			local normalized_path = vim.fn.fnamemodify(entry, ":p:h")
+			local name = vim.fn.fnamemodify(normalized_path, ":t")
 			return {
 				display = make_display,
 				name = name,

--- a/lua/project_explorer/explorer.lua
+++ b/lua/project_explorer/explorer.lua
@@ -97,12 +97,8 @@ local function get_dev_projects()
 			local min_depth = depth + 1
 			local max_depth = depth + 1
 			local clean_path = expanded_path:gsub("%*", "")
-			local command = string.format(
-				"find %s -mindepth %d -maxdepth %d -type d -not -name '.git'",
-				clean_path,
-				min_depth,
-				max_depth
-			)
+			local command = string.format(config.config.command_pattern, clean_path, min_depth, max_depth)
+
 			local handle = io.popen(command)
 			if handle then
 				for line in handle:lines() do


### PR DESCRIPTION
This PR introduces `command_pattern` which will allow the user to specify a `find` or other similar application command to find the directories. This is important because `find` on windows is used to search a file(s) for a string pattern. 

This also gives users flexibility to use their own tool for searching folders instead of being locked to one thing.